### PR TITLE
Remove reset of components triggered from the constructors. 

### DIFF
--- a/src/vcml/models/arm/pl011uart.cpp
+++ b/src/vcml/models/arm/pl011uart.cpp
@@ -212,8 +212,6 @@ namespace vcml { namespace arm {
         CID.allow_read();
 
         SC_METHOD(poll);
-
-        reset();
     }
 
     pl011uart::~pl011uart() {

--- a/src/vcml/models/arm/pl190vic.cpp
+++ b/src/vcml/models/arm/pl190vic.cpp
@@ -152,8 +152,6 @@ namespace vcml { namespace arm {
 
         PID.allow_read();
         CID.allow_read();
-
-        reset();
     }
 
     pl190vic::~pl190vic() {

--- a/src/vcml/models/arm/sp804timer.cpp
+++ b/src/vcml/models/arm/sp804timer.cpp
@@ -178,8 +178,6 @@ namespace vcml { namespace arm {
         SC_METHOD(update_IRQC);
         sensitive << IRQ1 << IRQ2;
         dont_initialize();
-
-        reset();
     }
 
     sp804timer::~sp804timer() {


### PR DESCRIPTION
**Symptom:** 
When creating the sp804timer the following SystemC error occurs: (E112) get interface failed: port is not bound: port 'xyz'. 

**Pseudo callstack:**
```
sp804timer.cpp:219 
     ...
     IRQC = false;
     ...

ports.h:53
     ...
     out_port& operator = (bool b) { write(b); return *this; }
     ...

ports.cpp:66
     ...
     if ((*this)->read() != set)
     ...

sc_port.h:452
    ...
    if( m_interface == 0 ) {
	report_error( SC_ID_GET_IF_, "port is not bound" );
    }
    ...
```
**Cause:**
If any port is read/written before binding happens, the sc_port object is not yet initialized. 

**Suggested solution:**
If a `reset()` function is triggered from a module's constructor, it must not write any signal right away. (e.g. in case of the sp804timer). Although this happens explicitly only in the sp804timer, other modules could be affected in the future: pl011uart and pl190vic also trigger a reset from the constructor. Luckily these are not reading/writing any ports. However, I suggest to remove the resets here as well: if these functions would change in the future, the same error might trigger. 

**Modeling repercussion:**
The `reset()` procedures of the noted models need to be triggered explicitly during platform construction - right after all port bindings were performed. For example in case of the AVP platform:
```
        ...
        m_timer0  = new vcml::arm::sp804timer("timer0");
        m_timer1  = new vcml::arm::sp804timer("timer1");
        m_uart0   = new vcml::arm::pl011uart("uart0");
        m_uart1   = new vcml::arm::pl011uart("uart1");
        m_uart2   = new vcml::arm::pl011uart("uart2");
        m_uart3   = new vcml::arm::pl011uart("uart3");
        ...
        m_timer0->IRQ1.bind(*m_irq_timer0_1);
        m_timer0->IRQ2.bind(*m_irq_timer0_2);
        m_timer0->IRQC.bind(*m_irq_timer0_c);
        m_timer1->IRQ1.bind(*m_irq_timer1_1);
        m_timer1->IRQ2.bind(*m_irq_timer1_2);
        m_timer1->IRQC.bind(*m_irq_timer1_c);
        m_uart0->IRQ.bind(*m_irq_uart0);
        m_uart1->IRQ.bind(*m_irq_uart1);
        m_uart2->IRQ.bind(*m_irq_uart2);
        m_uart3->IRQ.bind(*m_irq_uart3);

        // Trigger action for peripherals that require explicit reseting
        m_timer0->reset();
        m_timer1->reset();
        m_uart0->reset();
        m_uart1->reset();
        m_uart2->reset();
        m_uart3->reset();
        ...
```
I'm open for any suggestion to make this solution less ugly...