### PR TITLE
fix multicore PPI handling

### DIFF
--- a/src/vcml/models/arm/gicv2.cpp
+++ b/src/vcml/models/arm/gicv2.cpp
@@ -861,7 +861,7 @@ namespace vcml { namespace arm {
     }
 
     void gicv2::ppi_handler(unsigned int cpu, unsigned int irq) {
-        unsigned int idx = irq - VCML_ARM_GICv2_NSGI;
+        unsigned int idx = irq - VCML_ARM_GICv2_NSGI + cpu * VCML_ARM_GICv2_NPPI;
         unsigned int mask = 1 << cpu;
 
         bool irq_level = PPI_IN[idx].read();


### PR DESCRIPTION
ppi_handler should consider which cpu the the PPI belongs to. Else always the same PPI input will be checked regardless of cpu. See also 

https://github.com/aut0/vcml/blob/5ee6e2ca8c1bec827c5db90344560360c8cb8929/src/vcml/models/arm/gicv2.cpp#L896-L910

PPI 0-15 will be cpu0, 16-31 cpu1, ...