### PR TITLE
Special IRQs not considered in m_prev_irq

### DIFF
--- a/include/vcml/models/arm/gicv2.h
+++ b/include/vcml/models/arm/gicv2.h
@@ -32,10 +32,11 @@
 #include "vcml/peripheral.h"
 #include "vcml/slave_socket.h"
 
-#define VCML_ARM_GICv2_NCPU (8)    // number of CPUs handled by the ARM GIC
-#define VCML_ARM_GICv2_NIRQ (1020) // number of possible interrupts
-#define VCML_ARM_GICv2_NSGI (16)   // number of software generated interrupts
-#define VCML_ARM_GICv2_NPPI (16)   // number of private peripheral interrupts
+#define VCML_ARM_GICv2_NCPU (8)      // number of CPUs handled by the ARM GIC
+#define VCML_ARM_GICv2_NIRQ (1020)   // number of possible interrupts
+#define VCML_ARM_GICv2_NSPCL_IRQ (4) // number of special purpose IRQs
+#define VCML_ARM_GICv2_NSGI (16)     // number of software generated interrupts
+#define VCML_ARM_GICv2_NPPI (16)     // number of private peripheral interrupts
 #define VCML_ARM_GICv2_PRIV (VCML_ARM_GICv2_NSGI + VCML_ARM_GICv2_NPPI)
 
 #define VCML_ARM_GICv2_IDLE_PRIO     (0xFF)
@@ -181,7 +182,7 @@ namespace vcml { namespace arm {
             gicv2* m_parent;
 
             u32 m_curr_irq[VCML_ARM_GICv2_NCPU];
-            u32 m_prev_irq[VCML_ARM_GICv2_NIRQ][VCML_ARM_GICv2_NCPU];
+            u32 m_prev_irq[VCML_ARM_GICv2_NIRQ+VCML_ARM_GICv2_NSPCL_IRQ][VCML_ARM_GICv2_NCPU];
 
             void set_current_irq(unsigned int cpu_id, unsigned int irq);
 


### PR DESCRIPTION
Eventhough the special purpose interrupts are not used by peripherals, the configuration registers such as ICFGR exist for them according to the GICv2 spec and are eventually written by software. This can lead to out-of-bounds memory accesses because m_prev_irq is to small if interrupts >1020 are configured.

I added a define for VCML_ARM_GICv2_NSPCL_IRQ. The other line changes in that section are whitespace adjustements.