### PR TITLE
Fixed bug in sdcard model. 

### DIFF
--- a/src/vcml/models/generic/sdcard.cpp
+++ b/src/vcml/models/generic/sdcard.cpp
@@ -708,8 +708,8 @@ namespace vcml { namespace generic {
         /*** class 8 commands (application specific) ***/
 
         case 55: // APP_CMD (SD/SPI)
-            make_r1(tx);
             m_status |= APP_CMD;
+            make_r1(tx);
             return SD_OK;
 
         case 56: // GEN_CMD (SD/SPI)


### PR DESCRIPTION
m_status is used by make_r1, therefore it should be updated before make_r1 is called.