### PR TITLE
Sd bugfix

### DIFF
--- a/include/vcml/models/generic/sdcard.h
+++ b/include/vcml/models/generic/sdcard.h
@@ -58,16 +58,15 @@ namespace vcml { namespace generic {
         size_t  m_maxblk;
 
         enum state {
-            INACTIVE       = 0,
-            IDLE           = 1,
-            READY          = 2,
-            IDENTIFICATION = 3,
-            STAND_BY       = 4,
-            TRANSFER       = 5,
-            SENDING        = 6,
-            RECEIVING      = 7,
-            PROGRAMMING    = 8,
-            DISCONNECTED   = 9,
+            IDLE           = 0,
+            READY          = 1,
+            IDENTIFICATION = 2,
+            STAND_BY       = 3,
+            TRANSFER       = 4,
+            SENDING        = 5,
+            RECEIVING      = 6,
+            PROGRAMMING    = 7,
+            DISCONNECTED   = 8,
         };
 
         state m_state;
@@ -97,6 +96,11 @@ namespace vcml { namespace generic {
         void init_csd();
         void init_scr();
         void init_sts();
+
+        inline void update_m_status() {
+            m_status &= ~(0xf << 9);
+            m_status |= m_state << 9;
+        }
 
         void init_image();
 


### PR DESCRIPTION
I deleted state INACTIVE because it is not used in the sd card model. The advantage is that now the states have the identifier as specified in Physical Layer Simplified Specification on page 103.
I added the function update_m_status() that writes the sd card status m_state into the variable m_status. In non-spi responses r1 m_status is the main part of the response and the actual status m_state is otherwise never written to m_status. Note that the function update_m_status() is called after the response is generated because the Spec says that m_status includes the state when receiving the command (see page 103).

- CMD2 and CMD10 send the cid and CMD9 sends csd.
- when the tx.argument is 0, it is an inquiry
- in case SD_OK_TX_RDY and case SD_OK_RX_RDY the state must not set to SENDING or RECEIVING because all commands provoking a return SD_OK_TX_RDY or SD_OK_RX_RDY call setup_tx() or setup_rx() before returning and the m_state is set in this function to SENDING or RECEIVING.
