### PR TITLE
Linking issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ install:
 
 before_script:
   - mkdir BUILD && cd BUILD
-  - cmake .. -DVCML_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=$BUILD
+  - cmake .. -DCMAKE_CXX_FLAGS="-std=c++11" -DVCML_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=$BUILD
 
 script:
   - make -j 4 && ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,6 @@ set(sources
 
 add_library(vcml ${sources})
 set_target_properties(vcml PROPERTIES DEBUG_POSTFIX "d")
-target_compile_features(vcml PUBLIC cxx_std_11)
 target_compile_definitions(vcml PUBLIC $<$<CONFIG:DEBUG>:VCML_DEBUG>)
 
 target_include_directories(vcml PUBLIC ${inc})

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ for type in "DEBUG" "RELEASE"; do
     install="$home/BUILD/$type"
     build="$home/BUILD/$type/BUILD"
     mkdir -p $build && cd $build
-    cmake -DCMAKE_BUILD_TYPE=$type -DCMAKE_INSTALL_PREFIX=$install $home
+    cmake -DCMAKE_CXX_FLAGS="-std=c++11" -DCMAKE_BUILD_TYPE=$type -DCMAKE_INSTALL_PREFIX=$install $home
     make install
 done
 ```


### PR DESCRIPTION
cmake was unable to enforce C++11 with GCC 8.3.1 and GCC 9.4.0 from CMakeLists.txt.
The result was that VCML could not be linked to SystemC and the build failed.
Therefore, enforcement of C++11 it is now a parameter to the cmake command line call.