### PR TITLE
Fix order of or1k registers in rsp communication

### DIFF
--- a/src/vcml/debugging/gdbarch.cpp
+++ b/src/vcml/debugging/gdbarch.cpp
@@ -160,7 +160,7 @@ namespace vcml { namespace debugging {
             "r8",  "r9",  "r10", "r11", "r12", "r13", "r14", "r15",
             "r16", "r17", "r18", "r19", "r20", "r21", "r22", "r23",
             "r24", "r25", "r26", "r27", "r28", "r29", "r30", "r31",
-            "ppc", "npc", "sr" }},
+            "npc", "sr", "ppc" }},
     });
 
     const gdbarch gdbarch_riscv("riscv", "riscv", "none", {


### PR DESCRIPTION
Registers should appear in order of increasing register number (e.g. in 'g' and 'G' packets).