### PR TITLE
Fix stuck-in-time bug

### DIFF
--- a/src/vcml/processor.cpp
+++ b/src/vcml/processor.cpp
@@ -220,8 +220,15 @@ namespace vcml {
 
                 unsigned int num_cycles = 1;
                 sc_time quantum = tlm_global_quantum::instance().get();
-                if (quantum > clock_cycle() && quantum > local_time())
-                    num_cycles = (quantum - local_time()) / clock_cycle();
+                if (quantum > clock_cycle() && quantum > local_time()) {
+                    sc_time time_left = quantum - local_time();
+                    num_cycles = time_left / clock_cycle();
+
+                    // if there will be less than one clock_cycle left
+                    // in the current quantum -> do one more instruction
+                    if (time_left % clock_cycle() != SC_ZERO_TIME)
+                        ++num_cycles;
+                }
 
                 if (is_stepping())
                     num_cycles = 1;


### PR DESCRIPTION
If the quantum is not a multiple of clock_cycle, after calling `simulate(num_cycles)` there will be time left in the quantum. This
happens because `num_cycles` is rounded down. During the next iteration of the while loop, `num_cycles` will be set to 0. This leads to a not-increasing time, because `simulate(0)` is called which does not increase `local_time()`. To fix this behaviour, `num_cycles` is rounded up to ensure the full quantum can be used in each while loop iteration.