### PR TITLE
Fix gic400-cpu-index bug

### DIFF
--- a/src/vcml/models/arm/gic400.cpp
+++ b/src/vcml/models/arm/gic400.cpp
@@ -1308,8 +1308,8 @@ namespace vcml { namespace arm {
                                irq_payload& irq) {
         switch (socket.as) {
         case IRQ_AS_PPI: {
-            unsigned int cpu = PPI_IN.index_of(socket) / NCPU;
-            unsigned int idx = PPI_IN.index_of(socket) % NCPU;
+            unsigned int cpu = PPI_IN.index_of(socket) / NPPI;
+            unsigned int idx = PPI_IN.index_of(socket) % NPPI;
             handle_ppi(cpu, idx, irq);
             break;
         }


### PR DESCRIPTION
To get the CPU number of a PPI, the index of the socket needs to be divided by the number of supported PPIs instead of the number of supported CPUs.