### PR TITLE
Fix usage of invalid pointer

### DIFF
--- a/src/vcml/common/utils.cpp
+++ b/src/vcml/common/utils.cpp
@@ -239,7 +239,7 @@ namespace vcml {
             int status = 0;
             char* res = abi::__cxa_demangle(func, dmbuf, &dmbufsz, &status);
             if (status == 0) {
-                sv[i-skip] = string(dmbuf) + "+" + string(offset);
+                sv[i-skip] = string(res) + "+" + string(offset);
                 dmbuf = res; // dmbuf might get reallocated
             }
         }


### PR DESCRIPTION
The `__cxa__demangle` function gets a pointer to an allocated buffer (`dmbuf`) and the size of allocated memory (`dmbufsz`) as paramters. If the allocated size is not big enough to store the demangled name, more memory is allocated using `realloc`. The allocated size is updated (`dmbufsz`) and the pointer to the allocated memory is returned (`res`). The pointer to the originally allocated memory (`dmbufsz`) might be invalid if new memory is allocated using `realloc`.

[`abi::__cxa_demangle` documentation](https://gcc.gnu.org/onlinedocs/libstdc++/libstdc++-html-USERS-4.3/a01696.html)