### PR TITLE
Fix gic update bug

### DIFF
--- a/src/vcml/models/arm/gic400.cpp
+++ b/src/vcml/models/arm/gic400.cpp
@@ -700,6 +700,7 @@ namespace vcml { namespace arm {
             log_debug("(EOI) cpu %d eois irq %d", cpu, irq);
             set_current_irq(cpu, m_prev_irq[irq][cpu]);
             m_parent->set_irq_active(irq, false, 1 << cpu);
+            m_parent->update();
             return 0;
         }
 


### PR DESCRIPTION
If the interrupt acknowledge procedure has not been finished when a new interrupt is raised at the gic, this interrupt is not signaled to the CPU immediately because of the pending one. Once the pending interrupt is completely acknowledged (by writing to the EOI reg), the other pending interrupt should be signaled to the CPU. This is done by calling update after the acknowledged interrupt has been deactivated.