### PR TITLE
Avoid misinterpretation of simulation status

### DIFF
--- a/src/vcml/common/systemc.cpp
+++ b/src/vcml/common/systemc.cpp
@@ -626,8 +626,9 @@ sc_process_b* current_method() {
 }
 
 bool sim_running() {
-    sc_simcontext* simc = sc_get_curr_simcontext();
-    switch (simc->get_status()) {
+    sc_simcontext* simc             = sc_get_curr_simcontext();
+    const sc_core::sc_status status = simc->get_status();
+    switch (status) {
 #if SYSTEMC_VERSION >= SYSTEMC_VERSION_2_3_1a
     case sc_core::SC_END_OF_UPDATE:
         return true;
@@ -635,7 +636,7 @@ bool sim_running() {
         return true;
 #endif
     default:
-        return simc->get_status() < sc_core::SC_STOPPED;
+        return status < sc_core::SC_STOPPED;
     }
 }
 


### PR DESCRIPTION
`sim_running()` is not thread-safe & gets called by the rspserver thread,
e.g. while [handling a continue](https://github.com/janweinstock/vcml/blob/abbc42e89130de385aeec9d1b4c63130261b3ed0/src/vcml/debugging/gdbserver.cpp#L147) from a target gdb session.
The value of `simc->get_status()` could change between the switch
evaluation and the return evaluation in the default branch, and thus
could lead to a wrong return value.
In my case, this resulted in an unexpected/wrong SIGTRAP sent to the
target gdb.

This ensures at least a correct interpretation of the current simulation
status, by only calling `simc->get_status()` once.